### PR TITLE
データ管理にdynamoDB使用、S3トリガーLambdaを管理対象に追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 ││└(※app.pyが参照する自作モジュール格納フォルダ)
 │├app.py
 │├requirements.txt
+│├s3_object_put_handler.py
 │├samconfig.toml
 │└template.yaml
 ├uml
@@ -56,6 +57,9 @@ py -m pip install -r src\requirements.txt
 1. [AWS CLI をインストールする](https://docs.aws.amazon.com/ja_jp/cli/latest/userguide/cli-configure-files.html)
 1. [AWS CLI に IAM ユーザーの認証情報を設定する](https://docs.aws.amazon.com/ja_jp/cli/latest/userguide/cli-configure-files.html)
 
+#### Dockerインストール
+[Dockerのインストールを行う。](https://docs.aws.amazon.com/ja_jp/serverless-application-model/latest/developerguide/install-docker.html)
+
 #### デプロイ手順
 ※(python仮想環境を立ち上げていない場合、)ルートフォルダでコマンドラインを起動し、下記コマンドでpython仮想環境を起動する。
 ```dos
@@ -76,7 +80,7 @@ CloudFormation outputs from deployed stack
 Outputs
 ---------------------------------------------------------------------------------------------------------------------
 Key                 FunctionUrl
-Description         -
+Description         API Root URL
 Value               https://***.execute-api.(リージョン).amazonaws.com/(ステージ)/
 ---------------------------------------------------------------------------------------------------------------------
 Successfully created/updated stack - Epaper-apl-server-apim in (リージョン)
@@ -95,6 +99,7 @@ Successfully created/updated stack - Epaper-apl-server-apim in (リージョン)
 
 python仮想環境起動状態で、ルートフォルダから下記コマンドを実行する。
 ```dos
+cd src
 sam delete --no-prompts
 ```
 
@@ -331,7 +336,7 @@ src\samconfig.toml ファイルに下記設定を追加する。</br>
 ```src\samconfig.toml:toml
 [default.deploy.parameters]
 (略)
-parameter_overrides="StageName=(デプロイするステージ名) AwsS3Bucket=(画像アップロード/ダウンロード先S3バケット名) ApiKeyName=(APIキー名) LogLevel=(ログ出力レベル(0以下または数値以外:出力しない))"
+parameter_overrides="StageName=(デプロイするステージ名) AwsS3Bucket=(画像アップロード/ダウンロード先S3バケット名) ApiKeyName=(APIキー名) ImageMngDbTableName=(画像IDとURL管理DynamoDBテーブル名) LogLevel=(ログ出力レベル(0以下または数値以外:出力しない))"
 ```
 ※ルートフォルダでコマンドラインを起動し、python仮想環境を起動した上で下記のコマンドを実行することでも設定の変更が行える。
 ```dos
@@ -351,13 +356,14 @@ parameter_overrides="LogLevel=(ログ出力レベル(0以下または数値以�
 | StageName | ステージ名 | dev |
 | AwsS3Bucket | 画像アップロード/ダウンロード先S3バケット名 | 5.65-epaper-app-serever-assets |
 | ApiKeyName | APIキー名 | RestApiKey |
+| ImageMngDbTableName | 画像IDとURL管理DynamoDBテーブル名 | Image-ID-URL-mng |
 | LogLevel | ログ出力レベル</br>(0以下または数値以外:出力しない) | 10 |
 
 ### デプロイに失敗する
 - srcフォルダ以下に余分なファイルが存在していないか確認し、存在していた場合は余分なファイルを削除してからデプロイを実行する。</br>
 - しばらく時間をおいてからデプロイを行う。</br>
 時間をおいてもデプロイに失敗する場合、[【参考】デプロイした環境一式を削除したい場合](#3参考デプロイした環境一式を削除したい場合) を参考に、</br>
-AWS状の環境一式を削除したうえでデプロイを実行する。</br>
+AWS上の環境一式を削除したうえでデプロイを実行する。</br>
 <span style="color: red; ">**※削除を行うとAPIのルートURLが変更される。**</span>
 
 ### ローカルで動作確認を行いたい

--- a/_create_env.bat
+++ b/_create_env.bat
@@ -1,0 +1,19 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set curent_dir=%~dp0
+cd !curent_dir!
+
+set VENV_DIR=.venv
+rem python仮想環境フォルダが存在しない
+if not exist !VENV_DIR! (
+	rem python仮想環境を作成
+	py -m venv !VENV_DIR!
+)
+rem 仮想環境アクティブ化
+call !VENV_DIR!\Scripts\activate.bat
+rem ビルドに必要なライブラリをインストール
+py -m pip install -r .\bat\requirements.txt
+py -m pip install -r .\src\requirements.txt
+pause
+rem exit /b

--- a/_create_env.bat
+++ b/_create_env.bat
@@ -15,5 +15,6 @@ call !VENV_DIR!\Scripts\activate.bat
 rem ビルドに必要なライブラリをインストール
 py -m pip install -r .\bat\requirements.txt
 py -m pip install -r .\src\requirements.txt
-pause
-rem exit /b
+rem python仮想環境起動
+start !VENV_DIR!\Scripts\activate.bat
+exit /b

--- a/bat/requirements.txt
+++ b/bat/requirements.txt
@@ -1,0 +1,1 @@
+aws-sam-cli

--- a/src/app.py
+++ b/src/app.py
@@ -7,7 +7,7 @@ from module.logger_wrapper import cLoggerWrapper
 
 ENV_MNG = cEnvMng()
 LOGGER_WRAPPER:cLoggerWrapper = cLoggerWrapper(LEVEL=ENV_MNG.LOG_LEVEL)
-AWS_MNG = cAwsAccessMng(REGION_NAME=ENV_MNG.AWS_REGION, S3_BUCKET=ENV_MNG.AWS_S3_BUCKET, LOGGER_WRAPPER=LOGGER_WRAPPER)
+AWS_MNG = cAwsAccessMng(REGION_NAME=ENV_MNG.AWS_REGION, S3_BUCKET=ENV_MNG.AWS_S3_BUCKET, DYNAMO_DB_IMAGE_MNG_TABLE_NAME=ENV_MNG.AWS_DYNAMODB_IMAGE_MNG_TABLE_NAME, LOGGER_WRAPPER=LOGGER_WRAPPER)
 app = APIGatewayRestResolver()
 AWS_MNG.initialize()
 
@@ -37,7 +37,7 @@ def update_table() -> tuple[dict[str, str], int]:
     """
     LOGGER_WRAPPER.output(f'', PREFIX='::Enter')
     RESULT_DATAS:dict[str, str] = {cCommonFunc.API_RESP_DICT_KEY_RESULT:''}
-    STATUS = AWS_MNG.update_hash_table(API_RESULT_DATAS=RESULT_DATAS)
+    STATUS = AWS_MNG.force_update_image_mng_hash_table(API_RESULT_DATAS=RESULT_DATAS)
     _set_api_result_msg(STATUS_CODE=STATUS, RESULT_DATAS=RESULT_DATAS)
     LOGGER_WRAPPER.output(f'RESULT_DATAS:{RESULT_DATAS}, STATUS:{STATUS}', PREFIX='::Leave')
     return RESULT_DATAS, STATUS

--- a/src/module/aws_mng.py
+++ b/src/module/aws_mng.py
@@ -11,6 +11,8 @@ import json
 import logging
 import os.path as path
 
+from boto3.dynamodb.conditions import Key, Attr
+from boto3.dynamodb.types import TypeSerializer, TypeDeserializer
 from botocore.client import Config
 from botocore.exceptions import ClientError
 from datetime import datetime
@@ -23,20 +25,25 @@ class cAwsAccessMng:
     """AWSアクセス処理クラス
     """
 
-    def __init__(self, REGION_NAME:str = '', S3_BUCKET:str = '', LOGGER_WRAPPER:cLoggerWrapper = None) -> None:
+    def __init__(self, REGION_NAME:str = '', S3_BUCKET:str = '', DYNAMO_DB_IMAGE_MNG_TABLE_NAME:str = '', LOGGER_WRAPPER:cLoggerWrapper = None) -> None:
         """AWSアクセス処理クラスのコンストラクタ
 
         Args:
             REGION_NAME (str, optional): AWSリージョン名. Defaults to ''.
             S3_BUCKET (str, optional): AWS S3バケット名. Defaults to ''.
+            DYNAMO_DB_IMAGE_MNG_TABLE_NAME (str, optional): 画像IDとURL管理DynamoDBテーブル名. Defaults to ''.
             LOGGER_WRAPPER (cLoggerWrapper, optional): ログ出力管理クラスのインスタンス. Defaults to None.
         """
         self._region_name = REGION_NAME
         self._s3_bucket_name = S3_BUCKET
-        self._s3_client = None
-        self._dynamodb_resource = None
+        self._db_image_mng_table_name = DYNAMO_DB_IMAGE_MNG_TABLE_NAME
         self._logger_wrapper = LOGGER_WRAPPER
         self._image_url_hash_tables:list[dict[str, str|int]] = None
+        self._s3_client = None
+        self._dynamodb_client = None
+        self._dynamodb_img_mng_resource = None
+        self._serializer:TypeSerializer = None
+        self._deserializer:TypeDeserializer = None
 
     def __str__(self) -> str:
         """現在のオブジェクトを表す文字列を返す
@@ -48,10 +55,39 @@ class cAwsAccessMng:
         try:
             ret_value += f'REGION_NAME:{self.REGION_NAME}'
             ret_value += f', S3_BUCKET_NAME:{self.S3_BUCKET_NAME}'
+            ret_value += f', DYNAMO_DB_IMAGE_MNG_TABLE_NAME:{self.DYNAMO_DB_IMAGE_MNG_TABLE_NAME}'
             ret_value += f', len(ImageUrlHashTable):{-1 if self.ImageUrlHashTables is None else len(self.ImageUrlHashTables)}'
         except Exception as e:
             self.LOGGER_WRAPPER.output(MSG=f'ret_value:{ret_value}, {type(e).__name__}! {e}', LEVEL=logging.WARN)
         return ret_value
+
+    @property
+    def Serializer(self) -> TypeSerializer:
+        """dict → DynamoDB JSON変換を行うクラスのインスタンス 取得
+
+        Returns:
+            TypeSerializer: dict → DynamoDB JSON変換を行うクラスのインスタンス
+        """
+        if self._serializer is None:
+            try:
+                self._serializer = TypeSerializer()
+            except Exception as e:
+                self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, {type(e).__name__}! {e}', LEVEL=logging.WARN)
+        return self._serializer
+
+    @property
+    def Deserializer(self) -> TypeDeserializer:
+        """DynamoDB JSON → dict変換を行うクラスのインスタンス 取得
+
+        Returns:
+            TypeDeserializer: DynamoDB JSON → dict変換を行うクラスのインスタンス
+        """
+        if self._deserializer is None:
+            try:
+                self._deserializer = TypeDeserializer()
+            except Exception as e:
+                self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, {type(e).__name__}! {e}', LEVEL=logging.WARN)
+        return self._deserializer
 
     @property
     def MAX_S3_FILE_PATH_LENGTH(self) -> int:
@@ -104,6 +140,45 @@ class cAwsAccessMng:
         return self._s3_client
 
     @property
+    def DYNAMO_DB_IMAGE_MNG_TABLE_NAME(self) -> str:
+        """画像IDとURL管理DynamoDBテーブル名 取得
+
+        Returns:
+            str: 画像IDとURL管理DynamoDBテーブル名
+        """
+        return self._db_image_mng_table_name
+
+    @property
+    def DynamoDBClient(self):
+        """AWS DynamoDBクライアントのインスタンス 取得
+
+        Returns:
+            _type_: AWS DynamoDBクライアントのインスタンス
+        """
+        if self._dynamodb_client is None:
+            try:
+                self._dynamodb_client = boto3.client('dynamodb', region_name=self.REGION_NAME)
+            except Exception as e:
+                self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, {type(e).__name__}! {e}', LEVEL=logging.WARN)
+        return self._dynamodb_client
+
+    @property
+    def ImageMngDynamoDbResource(self):
+        """AWS DynamoDBリソースのインスタンス 取得
+
+        Returns:
+            _type_: AWS DynamoDBリソースのインスタンス
+        """
+        if self._dynamodb_img_mng_resource is None:
+            try:
+                self._dynamodb_img_mng_resource = boto3.resource(service_name='dynamodb', region_name=self.REGION_NAME)
+            except Exception as e:
+                self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, {type(e).__name__}! {e}', LEVEL=logging.WARN)
+        # テーブル作成
+        self._create_dynamo_db_table(DB_RESOURCE=self._dynamodb_img_mng_resource, TABLE_NAME=self.DYNAMO_DB_IMAGE_MNG_TABLE_NAME, ATTRIBUTE_DEFINITIONS=[{'AttributeName':cCommonFunc.API_RESP_DICT_KEY_ID, 'AttributeType':'S'}], KEY_SCHEMA=[{'AttributeName':cCommonFunc.API_RESP_DICT_KEY_ID, 'KeyType':'HASH'}], PROVISIONED_THROUGHPUT={'ReadCapacityUnits':5, 'WriteCapacityUnits':5})
+        return self._dynamodb_img_mng_resource
+
+    @property
     def S3_DB_NAME(self) -> str:
         """AWS S3に保持する画像ID・画像変換状態・画像URLのhash-tableリスト管理DB名 取得
 
@@ -149,16 +224,7 @@ class cAwsAccessMng:
             bool: 成功時はTrue、それ以外はFalse
         """
         self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>', PREFIX='::Enter')
-        ret_value = not self.S3_CLIENT is None and not cCommonFunc.is_none_or_empty(self.S3_DB_NAME)
-        if ret_value:
-            try:
-                OBJ = self.S3_CLIENT.get_object(Bucket=self.S3_BUCKET_NAME, Key=self.S3_DB_NAME)
-                self.ImageUrlHashTables = json.loads(OBJ['Body'].read()) if not OBJ is None and isinstance(OBJ, dict) and 'Body' in OBJ else {}
-            except Exception as e:
-                # 404エラー(DB不存在)以外のエラーの場合は処理失敗
-                if not isinstance(e, ClientError) or e.response['Error']['Code'] != '404':
-                    ret_value = False
-                    self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, {type(e).__name__}! {e}', LEVEL=logging.WARN)
+        ret_value = self._set_image_url_hash_table_from_db(IMAGE_HASH_TABLES=self.ImageUrlHashTables)
         self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>', PREFIX='::Leave')
         return ret_value
 
@@ -203,8 +269,8 @@ class cAwsAccessMng:
         self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, len(IMAGE_FILE_PATHS):{-1 if IMAGE_FILE_PATHS is None else len(IMAGE_FILE_PATHS)}, EXPIRATION:{EXPIRATION}, len(SIGNED_URLS):{-1 if SIGNED_URLS is None else len(SIGNED_URLS)}, ret_value:{ret_value}', PREFIX='::Leave')
         return ret_value
 
-    def update_hash_table(self, API_RESULT_DATAS:dict[str, str]) -> int:
-        """画像IDとURLのhash-tableアップデート
+    def force_update_image_mng_hash_table(self, API_RESULT_DATAS:dict[str, str]) -> int:
+        """画像IDとURLのhash-table強制アップデート
 
         Args:
             API_RESULT_DATAS (dict[str, str]): API応答内容dict
@@ -225,7 +291,7 @@ class cAwsAccessMng:
         # テーブル追加成功
         if ret_value == HTTPStatus.OK:
             # DB更新
-            ret_value = self._update_hash_table_db(API_RESULT_DATAS=API_RESULT_DATAS)
+            ret_value = self._force_update_db_from_hash_table(API_RESULT_DATAS=API_RESULT_DATAS)
 
         self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, len(S3_IMAGE_FILE_PATHS):{len(S3_IMAGE_FILE_PATHS)}, ret_value:{ret_value}', PREFIX='::Leave')
         return ret_value
@@ -243,15 +309,15 @@ class cAwsAccessMng:
         """
         self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, COUNT:{COUNT}, EXPIRATION:{EXPIRATION}', PREFIX='::Enter')
         DATAS:list[dict[str, str]] = None if API_RESULT_DATAS is None else API_RESULT_DATAS.get(cCommonFunc.API_RESP_DICT_KEY_DATA, None)
-        ret_value = HTTPStatus.OK if COUNT >= 0 and not DATAS is None and not self.ImageUrlHashTables is None else HTTPStatus.BAD_REQUEST if COUNT < 0 else HTTPStatus.INTERNAL_SERVER_ERROR
+        IMAGE_HASH_TABLE:list[dict[str, str|int]] = []
+        ret_value = HTTPStatus.OK if COUNT >= 0 and not DATAS is None and self._set_image_url_hash_table_from_db(IMAGE_HASH_TABLES=IMAGE_HASH_TABLE) else HTTPStatus.BAD_REQUEST if COUNT < 0 else HTTPStatus.INTERNAL_SERVER_ERROR
         if ret_value == HTTPStatus.OK:
             try:
                 DATAS.clear()
-                for TABLE in self.ImageUrlHashTables:
+                for TABLE in IMAGE_HASH_TABLE:
                     URL:str = TABLE.get(cCommonFunc.API_RESP_DICT_KEY_URL, '')
                     CONVERTIBLE:eImageConvertibleKind = TABLE.get(cCommonFunc.API_RESP_DICT_KEY_CONVERTIBLE, eImageConvertibleKind.UNDETERMINED)
                     DATAS.append({cCommonFunc.API_RESP_DICT_KEY_ID:TABLE.get(cCommonFunc.API_RESP_DICT_KEY_ID, ''), cCommonFunc.API_RESP_DICT_KEY_URL:self._get_signed_url(S3_CLIENT=self.S3_CLIENT, CLIENT_METHOD='get_object', EXPIRATION=EXPIRATION, OBJECT_KEY=URL), cCommonFunc.API_RESP_DICT_KEY_LAST_MODIFIED:TABLE.get(cCommonFunc.API_RESP_DICT_KEY_LAST_MODIFIED, ""), cCommonFunc.API_RESP_DICT_KEY_CONVERTIBLE:eImageConvertibleKind.get_name_from_value(VALUE=CONVERTIBLE)})
-                self.LOGGER_WRAPPER.output(MSG=f'DATAS:{DATAS}', PREFIX='::Debug') # TODO:後で消す
             except Exception as e:
                 ret_value = HTTPStatus.INTERNAL_SERVER_ERROR
                 # 例外内容をAPI処理結果詳細に設定
@@ -278,12 +344,21 @@ class cAwsAccessMng:
             int: httpステータスコード
         """
         self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, ID:{ID}, EXPIRATION:{EXPIRATION}', PREFIX='::Enter')
-        # IDがhash-table内に存在するか
-        ret_value = HTTPStatus.OK if self._is_exist_value_in_hash_table(KEY=cCommonFunc.API_RESP_DICT_KEY_ID, DST_VALUE=ID) else HTTPStatus.BAD_REQUEST
+        ret_value = HTTPStatus.OK if self._is_exist_id_in_dynamodb_image_mng_table(ID=ID) else HTTPStatus.BAD_REQUEST
         if ret_value == HTTPStatus.OK:
-            SRC_URL = [HASH_TABLE for HASH_TABLE in self.ImageUrlHashTables if HASH_TABLE.get(cCommonFunc.API_RESP_DICT_KEY_ID, '') == ID][0].get(cCommonFunc.API_RESP_DICT_KEY_URL, '')
-            # 署名付きURL(画像ダウンロード用)をAPI応答内容dictに設定
-            cCommonFunc.set_api_resp_str_msg(API_RESULT_DATAS=API_RESULT_DATAS, VALUE=self._get_signed_url(S3_CLIENT=self.S3_CLIENT, CLIENT_METHOD='get_object', EXPIRATION=EXPIRATION, OBJECT_KEY=SRC_URL), KEY=cCommonFunc.API_RESP_DICT_KEY_URL)
+            try:
+                DB_TABLE = self.ImageMngDynamoDbResource.Table(self.DYNAMO_DB_IMAGE_MNG_TABLE_NAME)
+                TABLE_RESULTS:list[dict] = DB_TABLE.query(KeyConditionExpression=Key(cCommonFunc.API_RESP_DICT_KEY_ID).eq(ID))
+                ITEMS:list[dict] = TABLE_RESULTS.get('Items', [])
+                DATA:dict = ITEMS[0] if not cCommonFunc.is_none_or_empty(ITEMS) else {}
+                SRC_URL = DATA.get(cCommonFunc.API_RESP_DICT_KEY_URL, "")
+                # 署名付きURL(画像ダウンロード用)をAPI応答内容dictに設定
+                cCommonFunc.set_api_resp_str_msg(API_RESULT_DATAS=API_RESULT_DATAS, VALUE=self._get_signed_url(S3_CLIENT=self.S3_CLIENT, CLIENT_METHOD='get_object', EXPIRATION=EXPIRATION, OBJECT_KEY=SRC_URL), KEY=cCommonFunc.API_RESP_DICT_KEY_URL)
+            except Exception as e:
+                ret_value = HTTPStatus.INTERNAL_SERVER_ERROR
+                # 例外内容をAPI処理結果詳細に設定
+                cCommonFunc.set_api_resp_str_msg(API_RESULT_DATAS=API_RESULT_DATAS, VALUE=f'{type(e).__name__}, {e}')
+                self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, ID:{ID}, EXPIRATION:{EXPIRATION}, {type(e).__name__}! {e}', LEVEL=logging.WARN)
         else:
             # リクエストデータに不正がある旨をAPI処理結果詳細に設定
             cCommonFunc.set_api_resp_str_msg(API_RESULT_DATAS=API_RESULT_DATAS, VALUE=f'ID is not exist in table!\n\tID:{ID}')
@@ -303,17 +378,125 @@ class cAwsAccessMng:
         """
         self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, ID:{ID}, CONVERTIBLE:{CONVERTIBLE}', PREFIX='::Enter')
         # IDがhash-table内に存在するか
-        ret_value = HTTPStatus.OK if self._is_exist_value_in_hash_table(KEY=cCommonFunc.API_RESP_DICT_KEY_ID, DST_VALUE=ID) else HTTPStatus.BAD_REQUEST
+        ret_value = HTTPStatus.OK if self._is_exist_id_in_dynamodb_image_mng_table(ID=ID) else HTTPStatus.BAD_REQUEST
         if ret_value == HTTPStatus.OK:
-            DST_TABLE = [HASH_TABLE for HASH_TABLE in self.ImageUrlHashTables if HASH_TABLE.get(cCommonFunc.API_RESP_DICT_KEY_ID, '') == ID][0]
-            # hash-tableの画像変換状態を更新
-            DST_TABLE[cCommonFunc.API_RESP_DICT_KEY_CONVERTIBLE] = eImageConvertibleKind.get_value_from_name(NAME=CONVERTIBLE)
-            # DB更新
-            ret_value = self._update_hash_table_db(API_RESULT_DATAS=API_RESULT_DATAS)
+            try:
+                KEY_SRC_CONVERTIBLE = '#attr_convertible'
+                KEY_DST_CONVERTIBLE = ':newConvertible'
+                DB_TABLE = self.ImageMngDynamoDbResource.Table(self.DYNAMO_DB_IMAGE_MNG_TABLE_NAME)
+                OPTION = {
+                    'Key': {cCommonFunc.API_RESP_DICT_KEY_ID:ID},
+                    'ExpressionAttributeNames': {KEY_SRC_CONVERTIBLE:cCommonFunc.API_RESP_DICT_KEY_CONVERTIBLE},
+                    'ExpressionAttributeValues': {f'{KEY_DST_CONVERTIBLE}': eImageConvertibleKind.get_value_from_name(NAME=CONVERTIBLE)},
+                    'UpdateExpression': f'set {KEY_SRC_CONVERTIBLE} = {KEY_DST_CONVERTIBLE}'
+                }
+                DB_TABLE.update_item(**OPTION)
+            except Exception as e:
+                ret_value = HTTPStatus.INTERNAL_SERVER_ERROR
+                # 例外内容をAPI処理結果詳細に設定
+                cCommonFunc.set_api_resp_str_msg(API_RESULT_DATAS=API_RESULT_DATAS, VALUE=f'{type(e).__name__}, {e}')
+                self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, ID:{ID}, CONVERTIBLE:{CONVERTIBLE}, {type(e).__name__}! {e}', LEVEL=logging.WARN)
         else:
             # リクエストデータに不正がある旨をAPI処理結果詳細に設定
             cCommonFunc.set_api_resp_str_msg(API_RESULT_DATAS=API_RESULT_DATAS, VALUE=f'ID is not exist in table!\n\tID:{ID}')
         self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, ID:{ID}, CONVERTIBLE:{CONVERTIBLE}, ret_value:{ret_value}', PREFIX='::Leave')
+        return ret_value
+
+    def putitem_to_dynamodb_image_mng_table(self, FILE_URL:str, LAST_MODIFIED:str, API_RESULT_DATAS:dict[str, str], id:str = None, CONVERTIBLE:eImageConvertibleKind = eImageConvertibleKind.UNDETERMINED, dynamo_table = None) -> int:
+        """AWS DynamoDBの画像IDと画像URL管理テーブルにアイテムを追加
+
+        Args:
+            FILE_URL (str): 画像URL
+            LAST_MODIFIED (str): 最終更新日時
+            API_RESULT_DATAS (dict[str, str]): API応答内容dict
+            id (str, optional): 画像ID. Defaults to None.
+            CONVERTIBLE (eImageConvertibleKind, optional): 画像フォーマット変換状態. Defaults to eImageConvertibleKind.UNDETERMINED.
+            dynamo_table (_type_, optional): DynamoDBの画像IDと画像URL管理テーブルのインスタンス. Defaults to None.
+
+        Returns:
+            int: httpステータスコード
+        """
+        ret_value = HTTPStatus.OK if not self.ImageMngDynamoDbResource is None and not cCommonFunc.is_none_or_empty(FILE_URL) else HTTPStatus.INTERNAL_SERVER_ERROR
+        if ret_value == HTTPStatus.OK:
+            try:
+                if id is None: id = str(uuid4())
+                if dynamo_table is None: dynamo_table = self.ImageMngDynamoDbResource.Table(self.DYNAMO_DB_IMAGE_MNG_TABLE_NAME)
+                ITEM = {cCommonFunc.API_RESP_DICT_KEY_ID:id, cCommonFunc.API_RESP_DICT_KEY_URL:FILE_URL, cCommonFunc.API_RESP_DICT_KEY_LAST_MODIFIED:LAST_MODIFIED, cCommonFunc.API_RESP_DICT_KEY_CONVERTIBLE:CONVERTIBLE}
+                dynamo_table.put_item(Item=ITEM)
+            except Exception as e:
+                ret_value = HTTPStatus.INTERNAL_SERVER_ERROR
+                # 例外内容をAPI処理結果詳細に設定
+                cCommonFunc.set_api_resp_str_msg(API_RESULT_DATAS=API_RESULT_DATAS, VALUE=f'{type(e).__name__}, {e}')
+                self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, FILE_URL:{FILE_URL}, {type(e).__name__}! {e}', LEVEL=logging.WARN)
+        return ret_value
+
+    def _create_dynamo_db_table(self, DB_RESOURCE, TABLE_NAME:str = '', KEY_SCHEMA:list[dict] = [], ATTRIBUTE_DEFINITIONS:list[dict] = [], PROVISIONED_THROUGHPUT:dict[str, int] = {}) -> bool:
+        """AWS SynamoDBのテーブル作成
+
+        Args:
+            DB_RESOURCE (_type_): AWS DynamoDBリソースのインスタンス
+            TABLE_NAME (str, optional): DynamoDBテーブル名. Defaults to ''.
+            KEY_SCHEMA (list[dict], optional): キースキーマ. Defaults to [].
+            ATTRIBUTE_DEFINITIONS (list[dict], optional): 属性. Defaults to [].
+            PROVISIONED_THROUGHPUT (dict[str, int], optional): テーブルのスループット. Defaults to {}.
+
+        Returns:
+            bool: 成功時はTrue、それ以外はFalse
+        """
+        ret_value = not DB_RESOURCE is None and not KEY_SCHEMA is None and not ATTRIBUTE_DEFINITIONS is None and not PROVISIONED_THROUGHPUT is None
+        # DBテーブルが不存在
+        if ret_value and not self._is_exist_dynamodb_table(TABLE_NAME=TABLE_NAME):
+            try:
+                TABLE = DB_RESOURCE.create_table(TableName=TABLE_NAME, KeySchema=KEY_SCHEMA, AttributeDefinitions=ATTRIBUTE_DEFINITIONS, ProvisionedThroughput=PROVISIONED_THROUGHPUT)
+                # テーブルが作成されるまで待つ
+                TABLE.meta.client.get_waiter('table_exists').wait(TableName=TABLE_NAME)
+            except Exception as e:
+                ret_value = False
+                self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, TABLE_NAME:{TABLE_NAME}, KEY_SCHEMA:{KEY_SCHEMA}, ATTRIBUTE_DEFINITIONS:{ATTRIBUTE_DEFINITIONS}, PROVISIONED_THROUGHPUT:{PROVISIONED_THROUGHPUT}, {type(e).__name__}! {e}', LEVEL=logging.WARN)
+        return ret_value
+
+    def _is_exist_dynamodb_table(self, TABLE_NAME:str) -> bool:
+        """DynamoDBに指定したテーブルが存在するか
+
+        Args:
+            TABLE_NAME (str): DynamoDBテーブル名
+
+        Returns:
+            bool: DynamoDBに指定したテーブルが存在する場合はTrue
+        """
+        ret_value = not self.DynamoDBClient is None and not cCommonFunc.is_none_or_empty(TABLE_NAME)
+        if ret_value:
+            try:
+                TABLES:dict = self.DynamoDBClient.list_tables()
+                ret_value = (TABLE_NAME in TABLES.get('TableNames', []))
+            except Exception as e:
+                ret_value = False
+                self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, TABLE_NAME:{TABLE_NAME}, {type(e).__name__}! {e}', LEVEL=logging.WARN)
+        return ret_value
+
+    def _set_image_url_hash_table_from_db(self, IMAGE_HASH_TABLES:list[dict[str, str|int]]) -> bool:
+        """DBから画像ID・画像変換状態・画像URLのhash-tableリスト設定
+
+        Args:
+            IMAGE_HASH_TABLES (list[dict[str, str | int]]): 画像ID・画像変換状態・画像URLのhash-tableリスト
+
+        Returns:
+            bool: 成功時はTrue、それ以外はFalse
+        """
+        ret_value = not IMAGE_HASH_TABLES is None and not self.ImageMngDynamoDbResource is None
+        # hash-tableリストクリア
+        if not IMAGE_HASH_TABLES is None: IMAGE_HASH_TABLES.clear()
+        # 管理DB(画像IDとURL)が存在する
+        if ret_value and self._is_exist_dynamodb_table(TABLE_NAME=self.DYNAMO_DB_IMAGE_MNG_TABLE_NAME):
+            try:
+                PAGINATOR = self.DynamoDBClient.get_paginator('scan')
+                for PAGE in PAGINATOR.paginate(TableName=self.DYNAMO_DB_IMAGE_MNG_TABLE_NAME):
+                    for PAGE_ITEM in PAGE.get('Items', {}):
+                        ITEM = {k:self.Deserializer.deserialize(v) for k, v in PAGE_ITEM.items()}
+                        IMAGE_HASH_TABLES.append(ITEM)
+            except Exception as e:
+                ret_value = False
+                self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, len(IMAGE_HASH_TABLES):{len(IMAGE_HASH_TABLES)}, {type(e).__name__}! {e}', LEVEL=logging.WARN)
         return ret_value
 
     def _create_s3_bucket(self, S3_CLIENT, API_RESULT_DATAS:dict[str, str]) -> bool:
@@ -428,12 +611,10 @@ class cAwsAccessMng:
                 IMAGE_FILE_PATHS.clear()
                 # S3内のファイル一覧を取得
                 OBJECTS = self.S3_CLIENT.list_objects(Bucket=self.S3_BUCKET_NAME, Prefix=self.S3_PREFIX)
-                self.LOGGER_WRAPPER.output(MSG=f'OBJECTS:{OBJECTS}', PREFIX='::Debug') # TODO:後で消す
                 if 'Contents' in OBJECTS:
                     for CONTENT in OBJECTS['Contents']:
                         if 'Key' in CONTENT and CONTENT['Size'] > 0:
                             IMAGE_FILE_PATHS.append({cCommonFunc.API_RESP_DICT_KEY_URL:CONTENT['Key'], cCommonFunc.API_RESP_DICT_KEY_LAST_MODIFIED:CONTENT.get("LastModified", "")})
-                self.LOGGER_WRAPPER.output(MSG=f'IMAGE_FILE_PATHS:{IMAGE_FILE_PATHS}', PREFIX='::Debug') # TODO:後で消す
             except Exception as e:
                 ret_value = HTTPStatus.INTERNAL_SERVER_ERROR
                 # 例外内容をAPI処理結果詳細に設定
@@ -457,32 +638,30 @@ class cAwsAccessMng:
         # 引数正常
         if ret_value == HTTPStatus.OK:
             try:
+                self.ImageUrlHashTables.clear()
                 for FILE_PATH_DICT in S3_IMAGE_FILE_PATH_DICTS:
                     FILE_PATH:str = FILE_PATH_DICT.get(cCommonFunc.API_RESP_DICT_KEY_URL, "")
                     LAST_MODIFIED = FILE_PATH_DICT.get(cCommonFunc.API_RESP_DICT_KEY_LAST_MODIFIED, datetime.min)
                     # hash-tableに存在しない画像ファイルパスの場合
                     if not self._is_exist_value_in_hash_table(KEY=cCommonFunc.API_RESP_DICT_KEY_URL, DST_VALUE=FILE_PATH):
                         TABLE:dict[str, str] = {}
-                        FILE_BASE_NAME:str = path.basename(FILE_PATH)
-                        # ID:ファイル名(※署名付きURL取得時にuuid4によるユニークIDが付与されており、S3アップロード時にユニークIDは既に存在する)
-                        TABLE[cCommonFunc.API_RESP_DICT_KEY_ID] = path.splitext(FILE_BASE_NAME)[0]
+                        TABLE[cCommonFunc.API_RESP_DICT_KEY_ID] = str(uuid4())
                         TABLE[cCommonFunc.API_RESP_DICT_KEY_URL] = FILE_PATH
                         TABLE[cCommonFunc.API_RESP_DICT_KEY_LAST_MODIFIED] = LAST_MODIFIED.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
                         TABLE[cCommonFunc.API_RESP_DICT_KEY_CONVERTIBLE] = eImageConvertibleKind.UNDETERMINED
-                        self.LOGGER_WRAPPER.output(MSG=f'TABLE:{TABLE}', PREFIX="::Debug") # TODO:後で消す
                         self.ImageUrlHashTables.append(TABLE)
             except Exception as e:
                 ret_value = HTTPStatus.INTERNAL_SERVER_ERROR
                 # 例外内容をAPI処理結果詳細に設定
                 cCommonFunc.set_api_resp_str_msg(API_RESULT_DATAS=API_RESULT_DATAS, VALUE=f'{type(e).__name__}, {e}')
-                self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, len(API_RESULT_DATAS):{-1 if API_RESULT_DATAS is None else len(API_RESULT_DATAS)}, len(S3_IMAGE_FILE_PATHS):{-1 if S3_IMAGE_FILE_PATH_DICTS is None else len(S3_IMAGE_FILE_PATH_DICTS)}, {type(e).__name__}! {e}', LEVEL=logging.WARN)
+                self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, len(API_RESULT_DATAS):{-1 if API_RESULT_DATAS is None else len(API_RESULT_DATAS)}, len(S3_IMAGE_FILE_PATH_DICTS):{-1 if S3_IMAGE_FILE_PATH_DICTS is None else len(S3_IMAGE_FILE_PATH_DICTS)}, {type(e).__name__}! {e}', LEVEL=logging.WARN)
         else:
             cCommonFunc.set_api_resp_str_msg(API_RESULT_DATAS=API_RESULT_DATAS, VALUE=f'hash-tables is None or parameter is invalid!\n, len(S3_IMAGE_FILE_PATHS):{-1 if S3_IMAGE_FILE_PATH_DICTS is None else len(S3_IMAGE_FILE_PATH_DICTS)}')
 
         return ret_value
 
-    def _update_hash_table_db(self, API_RESULT_DATAS:dict[str, str]) -> int:
-        """hash-table DB更新(※DBが存在しない場合は新規作成)
+    def _force_update_db_from_hash_table(self, API_RESULT_DATAS:dict[str, str]) -> int:
+        """画像IDと画像URL管理DB強制更新(※DBが存在しない場合は新規作成)
 
         Args:
             API_RESULT_DATAS (dict[str, str]): API応答内容dict
@@ -490,11 +669,15 @@ class cAwsAccessMng:
         Returns:
             int: httpステータスコード
         """
-        ret_value = HTTPStatus.OK if not self.ImageUrlHashTables is None and not cCommonFunc.is_none_or_empty(self.S3_BUCKET_NAME) and not cCommonFunc.is_none_or_empty(self.S3_DB_NAME) else HTTPStatus.INTERNAL_SERVER_ERROR
+        # ※テーブルを一旦削除する
+        ret_value = HTTPStatus.OK if not self.ImageUrlHashTables is None and self._delete_dynamodb_table_items(TABLE_NAME=self.DYNAMO_DB_IMAGE_MNG_TABLE_NAME) and not self.ImageMngDynamoDbResource is None else HTTPStatus.INTERNAL_SERVER_ERROR
         if ret_value == HTTPStatus.OK:
             try:
-                # DB更新
-                self.S3_CLIENT.put_object(Body=json.dumps(self.ImageUrlHashTables), Bucket=self.S3_BUCKET_NAME, Key=self.S3_DB_NAME)
+                DYNAMO_TABLE = self.ImageMngDynamoDbResource.Table(self.DYNAMO_DB_IMAGE_MNG_TABLE_NAME)
+                PUT_RESULTS:list[int] = []
+                for TABLE in self.ImageUrlHashTables:
+                    PUT_RESULTS.append(self.putitem_to_dynamodb_image_mng_table(FILE_URL=TABLE.get(cCommonFunc.API_RESP_DICT_KEY_URL, ''), LAST_MODIFIED=TABLE.get(cCommonFunc.API_RESP_DICT_KEY_LAST_MODIFIED, datetime.min.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]), CONVERTIBLE=TABLE.get(cCommonFunc.API_RESP_DICT_KEY_CONVERTIBLE, eImageConvertibleKind.UNDETERMINED), API_RESULT_DATAS=API_RESULT_DATAS, id=TABLE.get(cCommonFunc.API_RESP_DICT_KEY_ID, str(uuid4())), dynamo_table=DYNAMO_TABLE))
+                ret_value = max(PUT_RESULTS)
             except Exception as e:
                 ret_value = HTTPStatus.INTERNAL_SERVER_ERROR
                 # 例外内容をAPI処理結果詳細に設定
@@ -503,6 +686,58 @@ class cAwsAccessMng:
         else:
             # 内部変数に不正がある旨をAPI処理結果詳細に設定
             cCommonFunc.set_api_resp_str_msg(API_RESULT_DATAS=API_RESULT_DATAS, VALUE=f'hash-tables is None or internal parameter is invalid!, len(self.S3_BUCKET_NAME):{len(self.S3_BUCKET_NAME)}, len(self.S3_DB_NAME):{len(self.S3_DB_NAME)}')
+        return ret_value
+
+    def _delete_dynamodb_table_items(self, TABLE_NAME:str) -> bool:
+        """AWS DynamoDBのテーブル内アイテム全削除
+
+        Args:
+            TABLE_NAME (str): テーブル名
+
+        Returns:
+            bool: 成功時はTrue、それ以外はFalse
+        """
+        ret_value = not cCommonFunc.is_none_or_empty(TABLE_NAME)
+        # テーブルが存在する
+        if ret_value and self._is_exist_dynamodb_table(TABLE_NAME=TABLE_NAME) and not self.ImageMngDynamoDbResource is None:
+            try:
+                DELETE_ITEMS:list[dict] = []
+                PAGINATOR = self.DynamoDBClient.get_paginator('scan')
+                for PAGE in PAGINATOR.paginate(TableName=self.DYNAMO_DB_IMAGE_MNG_TABLE_NAME):
+                    DELETE_ITEMS.extend(PAGE.get('Items', {}))
+
+                DYNAMO_TABLE = self.ImageMngDynamoDbResource.Table(self.DYNAMO_DB_IMAGE_MNG_TABLE_NAME)
+                KEY_NAMES = [ x.get('AttributeName', "") for x in DYNAMO_TABLE.key_schema ]
+                DELETE_KEYS = [ { k:v for k,v in x.items() if k in KEY_NAMES } for x in DELETE_ITEMS ]
+
+                with DYNAMO_TABLE.batch_writer() as BATCH:
+                    for DEL_KEY in DELETE_KEYS:
+                        for KEY, VALUE in DEL_KEY.items():
+                            BATCH.delete_item(Key = {KEY:self.Deserializer.deserialize(VALUE)})
+            except Exception as e:
+                ret_value = False
+                self.LOGGER_WRAPPER.output(MSG=f'self:{self}, TABLE_NAME:{TABLE_NAME}, {type(e).__name__}! {e}', LEVEL=logging.WARN)
+        return ret_value
+
+    def _is_exist_id_in_dynamodb_image_mng_table(self, ID:str) -> bool:
+        """指定したIDがDynamoDBの「画像IDとURL管理テーブル」に存在するか
+
+        Args:
+            ID (str): 画像ID
+
+        Returns:
+            bool: 指定したIDがDynamoDBの「画像IDとURL管理テーブル」に存在する場合はTrue、それ以外はFalse
+        """
+        ret_value = not self.ImageMngDynamoDbResource is None
+        if ret_value:
+            try:
+                TABLE = self.ImageMngDynamoDbResource.Table(self.DYNAMO_DB_IMAGE_MNG_TABLE_NAME)
+                RESPONSE:dict = TABLE.query(KeyConditionExpression=Key(cCommonFunc.API_RESP_DICT_KEY_ID).eq(ID))
+                COUNT = RESPONSE.get('Count', 0)
+                ret_value = COUNT > 0
+            except Exception as e:
+                ret_value = False
+                self.LOGGER_WRAPPER.output(MSG=f'self:<{self}>, ID:{ID}, {type(e).__name__}! {e}', LEVEL=logging.WARN)
         return ret_value
 
     def _is_exist_value_in_hash_table(self, KEY:str, DST_VALUE:str) -> bool:

--- a/src/module/env_mng.py
+++ b/src/module/env_mng.py
@@ -23,6 +23,7 @@ class cEnvMng:
         try:
             ret_value += f'AWS_REGION:{self.AWS_REGION}'
             ret_value += f', AWS_S3_BUCKET:{self.AWS_S3_BUCKET}'
+            ret_value += f', AWS_DYNAMODB_IMAGE_MNG_TABLE_NAME:{self.AWS_DYNAMODB_IMAGE_MNG_TABLE_NAME}'
 
             ret_value += f', LOG_LEVEL:{self.LOG_LEVEL}'
         except Exception as e:
@@ -46,6 +47,15 @@ class cEnvMng:
             str: AWS S3バケット名
         """
         return os.getenv('AWS_S3_BUCKET', '')
+
+    @property
+    def AWS_DYNAMODB_IMAGE_MNG_TABLE_NAME(self) -> str:
+        """画像IDとURL管理DynamoDBテーブル名 取得
+
+        Returns:
+            str: 画像IDとURL管理DynamoDBテーブル名
+        """
+        return os.getenv('AWS_DYNAMODB_IMAGE_MNG_TABLE_NAME', '')
 
     @property
     def LOG_LEVEL(self) -> int:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,3 @@
 python-dotenv
 boto3
-aws-sam-cli
 aws-lambda-powertools

--- a/src/s3_object_put_handler.py
+++ b/src/s3_object_put_handler.py
@@ -1,0 +1,85 @@
+"""S3へのオブジェクトアップロードイベントハンドラ
+"""
+import dateutil.parser as du_parser
+import logging
+
+from http import HTTPStatus
+from module.aws_mng import cAwsAccessMng
+from module.common_func import cCommonFunc
+from module.env_mng import cEnvMng
+from module.logger_wrapper import cLoggerWrapper
+
+ENV_MNG = cEnvMng()
+LOGGER_WRAPPER:cLoggerWrapper = cLoggerWrapper(LEVEL=ENV_MNG.LOG_LEVEL)
+AWS_MNG = cAwsAccessMng(REGION_NAME=ENV_MNG.AWS_REGION, S3_BUCKET=ENV_MNG.AWS_S3_BUCKET, DYNAMO_DB_IMAGE_MNG_TABLE_NAME=ENV_MNG.AWS_DYNAMODB_IMAGE_MNG_TABLE_NAME, LOGGER_WRAPPER=LOGGER_WRAPPER)
+AWS_MNG.initialize()
+DICT_KEY_TIME = 'time'
+DICT_KEY_FILE_NAME = 'file_name'
+
+def lambda_handler(event, context):
+    LOGGER_WRAPPER.output(MSG=f'', PREFIX='::Enter')
+    RESULT_DATAS:dict[str, str] = {cCommonFunc.API_RESP_DICT_KEY_RESULT:''}
+    S3_OBJECT_DATAS:list[str] = [] # イベント内のS3オブジェクトの日時・ファイル名リスト
+    # S3オブジェクトの日時・ファイル名リストを設定
+    status = get_s3_event_object_keys(RECORDS=event.get('Records', []), S3_OBJECT_DATAS=S3_OBJECT_DATAS, API_RESULT_DATAS=RESULT_DATAS)
+    # S3オブジェクトの日時・ファイル名リスト設定成功
+    if status == HTTPStatus.OK:
+        # DB更新処理呼び出し
+        status = call_update_db_func(S3_OBJECT_DATAS=S3_OBJECT_DATAS, API_RESULT_DATAS=RESULT_DATAS)
+    LOGGER_WRAPPER.output(MSG=f'status:{status}, RESULT_DATAS:{RESULT_DATAS}', PREFIX='::Leave')
+    return RESULT_DATAS, status
+
+def get_s3_event_object_keys(RECORDS:list[dict[str, str|dict]], S3_OBJECT_DATAS:list[dict], API_RESULT_DATAS:dict[str, str]) -> int:
+    """S3オブジェクトの日時・ファイル名リストを設定
+
+    Args:
+        RECORDS (list[dict[str, str | dict]]): レコード(lambda_handlerのイベント)
+        S3_OBJECT_DATAS (list[dict]): S3オブジェクトの日時・ファイル名リスト
+        API_RESULT_DATAS (dict[str, str]): 応答内容dict
+
+    Returns:
+        int: httpステータスコード
+    """
+    LOGGER_WRAPPER.output(MSG=f'len(RECORDS):{-1 if RECORDS is None else len(RECORDS)}', PREFIX='::Enter')
+    ret_value = HTTPStatus.OK if not cCommonFunc.is_none_or_empty(RECORDS) and not S3_OBJECT_DATAS is None else HTTPStatus.INTERNAL_SERVER_ERROR
+    if ret_value == HTTPStatus.OK:
+        try:
+            S3_OBJECT_DATAS.clear()
+            for RECORD in RECORDS:
+                EVENT_TIME:str = RECORD.get('eventTime', "")
+                S3_OBJECT:dict = RECORD.get('s3', {}).get('object', {})
+                if 'key' in S3_OBJECT and not cCommonFunc.is_none_or_empty(EVENT_TIME):
+                    S3_OBJECT_DATAS.append({DICT_KEY_FILE_NAME:S3_OBJECT.get('key'), DICT_KEY_TIME:du_parser.parse(EVENT_TIME).strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]})
+        except Exception as e:
+            ret_value = HTTPStatus.INTERNAL_SERVER_ERROR
+            # 例外内容をAPI処理結果詳細に設定
+            cCommonFunc.set_api_resp_str_msg(API_RESULT_DATAS=API_RESULT_DATAS, VALUE=f'{type(e).__name__}, {e}')
+            LOGGER_WRAPPER.output(MSG=f'len(RECORDS):{-1 if RECORDS is None else len(RECORDS)}, len(S3_OBJECT_DATAS):{-1 if S3_OBJECT_DATAS is None else len(S3_OBJECT_DATAS)}, {type(e).__name__}! {e}', LEVEL=logging.WARN)
+    LOGGER_WRAPPER.output(MSG=f'len(RECORDS):{-1 if RECORDS is None else len(RECORDS)}, len(S3_OBJECT_DATAS):{-1 if S3_OBJECT_DATAS is None else len(S3_OBJECT_DATAS)}, ret_value:{ret_value}', PREFIX='::Leave')
+    return ret_value
+
+def call_update_db_func(S3_OBJECT_DATAS:list[dict], API_RESULT_DATAS:dict[str, str]) -> int:
+    """DB更新処理呼び出し
+
+    Args:
+        S3_OBJECT_DATAS (list[dict]): S3オブジェクトの日時・ファイル名リスト
+        API_RESULT_DATAS (dict[str, str]): 応答内容dict
+
+    Returns:
+        int: httpステータスコード
+    """
+    LOGGER_WRAPPER.output(MSG=f'len(S3_OBJECT_DATAS):{-1 if S3_OBJECT_DATAS is None else len(S3_OBJECT_DATAS)}', PREFIX='::Enter')
+    ret_value = HTTPStatus.OK if not S3_OBJECT_DATAS is None and not AWS_MNG is None else HTTPStatus.INTERNAL_SERVER_ERROR
+    if ret_value == HTTPStatus.OK:
+        try:
+            PUT_RESULTS:list[int] = []
+            for OBJECT in S3_OBJECT_DATAS:
+                PUT_RESULTS.append(AWS_MNG.putitem_to_dynamodb_image_mng_table(FILE_URL=OBJECT.get(DICT_KEY_FILE_NAME, ''), LAST_MODIFIED=OBJECT.get(DICT_KEY_TIME, ''), API_RESULT_DATAS=API_RESULT_DATAS))
+            ret_value = max(PUT_RESULTS)
+        except Exception as e:
+            ret_value = HTTPStatus.INTERNAL_SERVER_ERROR
+            # 例外内容をAPI処理結果詳細に設定
+            cCommonFunc.set_api_resp_str_msg(API_RESULT_DATAS=API_RESULT_DATAS, VALUE=f'{type(e).__name__}, {e}')
+            LOGGER_WRAPPER.output(MSG=f'len(S3_OBJECT_DATAS):{-1 if S3_OBJECT_DATAS is None else len(S3_OBJECT_DATAS)}, {type(e).__name__}! {e}', LEVEL=logging.WARN)
+    LOGGER_WRAPPER.output(MSG=f'len(S3_OBJECT_DATAS):{-1 if S3_OBJECT_DATAS is None else len(S3_OBJECT_DATAS)}, ret_value:{ret_value}', PREFIX='::Leave')
+    return ret_value

--- a/src/template.yaml
+++ b/src/template.yaml
@@ -15,10 +15,18 @@ Parameters:
     Type: String
     Default: RestApiKey
     Description: APIキー名
+  Prefix:
+    Type: String
+    Default: "images/"
+    Description: 通知対象のファイルのPrefix(フォルダ等)
+  ImageMngDbTableName:
+    Type: String
+    Default: Image-ID-URL-mng
+    Description: 画像IDとURL管理DynamoDBテーブル名
   LogLevel:
     Type: String
     Default: "10"
-    Description: ログ出力レベル(0以下または数値以外:出力しない)
+    Description: ログ出力レベル(0以下 または 数値以外:出力しない)
 
 Resources:
   # AmazonAPIGatewayリソースとメソッドのコレクション
@@ -38,13 +46,12 @@ Resources:
       CodeUri: ./
       Handler: app.lambda_handler
       Runtime: python3.12
-      Policies:
-        # S3アクセス許可
-        - S3CrudPolicy:
-            BucketName: !Sub ${AwsS3Bucket}
+      Timeout: 30
+      Role: !GetAtt LambdaIAMRole.Arn
       Environment:
         Variables:
           AWS_S3_BUCKET: !Sub ${AwsS3Bucket}
+          AWS_DYNAMODB_IMAGE_MNG_TABLE_NAME: !Sub ${ImageMngDbTableName}
           LOG_LEVEL: !Sub ${LogLevel}
       Events:
         ApiProxy:
@@ -53,6 +60,57 @@ Resources:
             Path: '/{proxy+}'
             Method: ANY
             RestApiId: !Ref ApiGatewayRestApi
+
+  # IAMロール
+  LambdaIAMRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AmazonS3FullAccess'
+        - 'arn:aws:iam::aws:policy/AmazonRekognitionFullAccess'
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 's3:GetBucketNotification'
+                  - 's3:PutBucketNotification'
+                Resource: !Sub 'arn:aws:s3:::${AwsS3Bucket}'
+              - Effect: Allow
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                Resource: 'arn:aws:logs:*:*:*'
+              - Effect: "Allow"
+                Action:
+                  - "dynamodb:ListTables"
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - 'dynamodb:CreateTable'
+                  - 'dynamodb:DeleteTable'
+                  - 'dynamodb:DescribeTable'
+                  - 'dynamodb:Scan'
+                  - 'dynamodb:Query'
+                  - 'dynamodb:GetItem'
+                  - 'dynamodb:PutItem'
+                  - 'dynamodb:UpdateItem'
+                  - 'dynamodb:DeleteItem'
+                  - 'dynamodb:BatchWriteItem'
+                Resource: !Sub 'arn:aws:dynamodb:*:*:table/${ImageMngDbTableName}'
 
   # APIキー
   RestApiKey:
@@ -97,12 +155,138 @@ Resources:
       KeyType: API_KEY
       UsagePlanId: !Ref ApiUsagePlan
 
-  # ロググループ
+  # ルーティング処理関数のロググループ
   FunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${ApiLambdaFunction}
       RetentionInDays: 30
+
+  # S3からの通知を受け取るLambda
+  S3NotificationLambdaFunction:
+    Type: 'AWS::Serverless::Function'
+    DependsOn: LambdaIAMRole
+    Properties:
+      CodeUri: ./
+      Handler: s3_object_put_handler.lambda_handler
+      Role: !GetAtt LambdaIAMRole.Arn
+      Runtime: python3.12
+      Timeout: 5
+      Environment:
+        Variables:
+          AWS_S3_BUCKET: !Sub ${AwsS3Bucket}
+          AWS_DYNAMODB_IMAGE_MNG_TABLE_NAME: !Sub ${ImageMngDbTableName}
+          LOG_LEVEL: !Sub ${LogLevel}
+
+  # S3からの通知を受け取るLambdaのロググループ
+  S3NotificationLambdaFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    DependsOn: LambdaIAMRole
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${S3NotificationLambdaFunction}
+      RetentionInDays: 30
+
+  # S3からの通知を受け取るLambdaの使用許可
+  LambdaInvokePermission:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      FunctionName: !GetAtt S3NotificationLambdaFunction.Arn
+      Action: 'lambda:InvokeFunction'
+      Principal: s3.amazonaws.com
+      SourceAccount: !Ref 'AWS::AccountId'
+      SourceArn: !Sub 'arn:aws:s3:::${AwsS3Bucket}'
+
+  # S3通知を設定するLambda
+  CustomResourceLambdaFunction:
+    Type: 'AWS::Lambda::Function'
+    DependsOn: LambdaIAMRole
+    Properties:
+      Handler: index.lambda_handler
+      Role: !GetAtt LambdaIAMRole.Arn
+      Code:
+        ZipFile: |
+
+            from datetime import datetime
+            from logging import getLogger, Logger
+            import json
+            import boto3
+            import cfnresponse
+
+            LOGGER:Logger = getLogger(__name__)
+            LOGGER.setLevel(10)
+
+            LOGGER.info(f'{datetime.now().strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]}\tLoading function')
+            s3 = boto3.resource('s3')
+
+            def lambda_handler(event, context):
+                LOGGER.info(f'{datetime.now().strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]}\t[lambda_handler::Enter]Received event:{json.dumps(event, indent=2)}')
+                responseData={}
+                try:
+                    LOGGER.info(f'{datetime.now().strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]}\t[lambda_handler]Request Type:{event.get("RequestType", "(unknown)")}')
+                    if event['RequestType'] == 'Delete':
+                        Bucket=event['ResourceProperties']['Bucket']
+                        delete_notification(Bucket)
+                        LOGGER.info("Sending response to custom resource after Delete")
+                    elif event['RequestType'] == 'Create' or event['RequestType'] == 'Update':
+                        LambdaArn=event['ResourceProperties']['LambdaArn']
+                        Bucket=event['ResourceProperties']['Bucket']
+                        Prefix=event['ResourceProperties']['Prefix']
+                        add_notification(LambdaArn, Bucket, Prefix)
+                        responseData={'Bucket':Bucket}
+                        LOGGER.info("Sending response to custom resource")
+                    responseStatus = 'SUCCESS'
+                except Exception as e:
+                    LOGGER.info('Failed to process:', e)
+                    responseStatus = 'FAILED'
+                    responseData = {'Failure': 'Something bad happened.'}
+                cfnresponse.send(event, context, responseStatus, responseData)
+                LOGGER.info(f'{datetime.now().strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]}\t[lambda_handler::Leave]responseStatus:{responseStatus}')
+
+            def add_notification(LambdaArn, Bucket, Prefix):
+                bucket_notification = s3.BucketNotification(Bucket)
+                response = bucket_notification.put(
+                  NotificationConfiguration={
+                    'LambdaFunctionConfigurations': [
+                      {
+                          'LambdaFunctionArn': LambdaArn,
+                          'Events': [
+                              's3:ObjectCreated:*'
+                          ],
+                          'Filter': {'Key': {'FilterRules': [
+                            {'Name': 'Prefix', 'Value': Prefix}
+                          ]}}
+                      }
+                    ]
+                  }
+                )
+                LOGGER.info(f'{datetime.now().strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]}\tPut request completed....')
+
+            def delete_notification(Bucket):
+                bucket_notification = s3.BucketNotification(Bucket)
+                response = bucket_notification.put(
+                    NotificationConfiguration={}
+                )
+                LOGGER.info(f'{datetime.now().strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]}\tDelete request completed....')
+      Runtime: python3.12
+      Timeout: 30
+
+  # ロググループ
+  CustomResourceLambdaFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    DependsOn: LambdaIAMRole
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${CustomResourceLambdaFunction}
+      RetentionInDays: 30
+
+  # S3通知の設定
+  LambdaTrigger:
+    Type: 'Custom::LambdaTrigger'
+    DependsOn: LambdaInvokePermission
+    Properties:
+      ServiceToken: !GetAtt CustomResourceLambdaFunction.Arn
+      LambdaArn: !GetAtt S3NotificationLambdaFunction.Arn
+      Bucket: !Ref AwsS3Bucket
+      Prefix: !Ref Prefix
 
 Outputs:
   FunctionUrl:

--- a/uml/sequence/ESL_sequence.pu
+++ b/uml/sequence/ESL_sequence.pu
@@ -5,15 +5,15 @@ hide footbox
 actor "ユーザ" as user
 participant "クライアントアプリ" as cltapp
 participant "AWS Lambda" as aws_lambda
+database "画像ID⇔画像URLの紐づけ\n(AWS DynamoDB)" as hash_table
 participant "AWS S3" as aws_s3
-database "hash-table\n画像ID⇔画像URLの紐づけ\n(AWS S3保存)" as hash_table
 database "画像ファイル\n(AWS S3保存)" as imageDatas
 participant "Epaper SDKサーバ" as sdksrv
 participant "Epaper端末" as epaper
 
 == AWS Lambda コールドスタート ==
 note over aws_lambda, imageDatas
-    ※S3へのアクセス設定はLambda側で設定済みとする
+    ※DynamoDBへのアクセス設定はLambda側に設定済みとする
 end note
 [->>aws_lambda ++ : コールドスタート
 aws_lambda -> hash_table : 取得
@@ -26,7 +26,7 @@ user ->> cltapp ++ : カメラ撮影 or\nアルバムから選択 or\nトリミ�
 cltapp -> aws_lambda ++ : 署名付きURL取得\n(アップロード対象画像ファイルパスリスト)
 
 note over aws_lambda, imageDatas
-    ※S3へのアクセス設定はlambda側で設定済みとする
+    ※S3へのアクセス設定はlambda側に設定済みとする
 end note
 loop アップロード対象画像ファイルパスリストの要素数
     aws_lambda -> aws_s3 ++ : 署名付きURL取得\n(画像ファイルパス)
@@ -36,7 +36,7 @@ cltapp <-- aws_lambda -- : 署名付きURL取得 応答\n(ステータスコー�
 
 opt 署名付きURL取得 応答が正常
     loop 追加登録画像数
-        cltapp -> imageDatas : ファイルアップロード\n(画像ファイル ※リサイズ済)
+        cltapp -> imageDatas : ファイルアップロード\n(画像ファイル)
     end
 end
 user <<-- cltapp --
@@ -47,19 +47,16 @@ note over user
     のいずれかに遷移
 end note
 
-aws_s3 ->> aws_lambda ++ : ファイルアップロードイベント(アップロードファイルパス)
-critical hash-table更新
-    opt 内部変数(hash-table)に画像ファイルパスが無い
-        aws_lambda -> aws_lambda : 内部変数(hash-table)更新
-        aws_lambda -> hash_table : DB更新
-    end
+aws_s3 ->> aws_lambda ++ : ファイルアップロードイベント(アップロードされたファイルパス)
+aws_lambda -> hash_table : DB更新
 deactivate aws_lambda
-end
 
 
 == 配信用画像を一覧表示 ==
 user ->> cltapp ++ : サムネ画像表示画面遷移
 cltapp -> aws_lambda ++ : 画像リスト要求\n()
+aws_lambda -> hash_table : 取得
+aws_lambda <-- hash_table
 cltapp <-- aws_lambda -- : 画像リスト要求 応答\n(ステータスコード, 画像IDに対応する画像URLリスト)
 loop 画像IDに対応する画像URLリスト要素数
     cltapp -> imageDatas ++ : 画像取得\n()
@@ -87,10 +84,7 @@ par
 else
     cltapp ->> aws_lambda ++ : 画像情報更新\n(ID, 画像変換結果)
     user <<-- cltapp --
-    critical hash-table更新
-        aws_lambda -> aws_lambda : 内部変数(hash-table)更新
-        aws_lambda -> hash_table : DB更新
-    end
+    aws_lambda -> hash_table : DB更新
     deactivate aws_lambda
 end
 

--- a/uml/sequence/ESL_sequence.pu
+++ b/uml/sequence/ESL_sequence.pu
@@ -47,16 +47,14 @@ note over user
     のいずれかに遷移
 end note
 
-aws_s3 ->> aws_lambda ++ : ファイルアップロードイベント()
-aws_lambda -> aws_s3 ++ : フォルダ内ファイル名一覧取得\n()
-aws_lambda <-- aws_s3 -- : フォルダ内ファイル名一覧取得 応答\n(フォルダ内ファイル名一覧)
-loop S3フォルダ内ファイル数
+aws_s3 ->> aws_lambda ++ : ファイルアップロードイベント(アップロードファイルパス)
+critical hash-table更新
     opt 内部変数(hash-table)に画像ファイルパスが無い
         aws_lambda -> aws_lambda : 内部変数(hash-table)更新
+        aws_lambda -> hash_table : DB更新
     end
-end
 deactivate aws_lambda
-aws_lambda -> hash_table : DB更新
+end
 
 
 == 配信用画像を一覧表示 ==


### PR DESCRIPTION
・画像IDと画像URLの保存をdynamoDBで行うように修正。
・S3へのファイルアップロードをトリガーとするLambda関数を管理対象に追加。
・デプロイ環境作成用バッチファイルを追加。
・シーケンス図のDB(画像ID⇔画像URLの紐づけ)を"S3管理 → DynamoDB管理"に修正。